### PR TITLE
fix the bug while tiling xx type scene

### DIFF
--- a/tiling.py
+++ b/tiling.py
@@ -400,7 +400,7 @@ class LineKernel(object):
         for i in range(self._diameter):
             pos = np.array((i - self._radius)) + np.array(self._center)
             translate = utils.translation_matrix(
-                pos * self._group.translational_subgroup_basis[1 if (pos % 2) == 0 else 0])
+                abs(pos) * self._group.translational_subgroup_basis[1 if pos > 0 else 0])
 
             prism = shapes.Prism(self._group.height, *self._group.translational_fd_vertices)
 


### PR DESCRIPTION
while tiling, the fds far away are not connected #2. After the changing, the problem is solved. A test screenshot is attached
![image](https://user-images.githubusercontent.com/6183742/29698506-c5b0229a-890a-11e7-8704-3a2505f0fb56.png)
